### PR TITLE
Update keyboard header

### DIFF
--- a/usb_desc.h
+++ b/usb_desc.h
@@ -337,10 +337,10 @@ let me know?  http://forum.pjrc.com/forums/4-Suggestions-amp-Bug-Reports
 		#define SEREMU_RX_ENDPOINT    2
 		#define SEREMU_RX_SIZE        32
 		#define SEREMU_RX_INTERVAL    2
-		#define KEYBOARD_INTERFACE    0	// Keyboard
-		#define KEYBOARD_ENDPOINT     7
-		#define KEYBOARD_SIZE         8
-		#define KEYBOARD_INTERVAL     5
+    #define KEYBOARD_INTERFACE    0	// Keyboard
+    #define KEYBOARD_ENDPOINT     3
+    #define KEYBOARD_SIZE         8
+    #define KEYBOARD_INTERVAL     1
 		#define ENDPOINT1_CONFIG	ENDPOINT_TRANSIMIT_ONLY
 		#define ENDPOINT2_CONFIG	ENDPOINT_RECEIVE_ONLY
 		#define ENDPOINT3_CONFIG	ENDPOINT_TRANSIMIT_ONLY


### PR DESCRIPTION
Updates what I believe to be the duo header with HID keyboard support. [ heres where the updated numbers came from ](https://github.com/PaulStoffregen/cores/blob/fcece8099baf1081f77d36628f2ac7de5fd70cf4/teensy3/usb_desc.h#L275)

this code is pretty arcane to me though. Also I dont have test hardware so this is just speculation of how I think things work in my happy little world. 
Could maybe fix, https://github.com/trustcrypto/OnlyKey-Firmware/issues/135
